### PR TITLE
Modularize ParT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Make ParT `ffn_ratio` and `embed_dims` more modular
+
 ## [1.3.5] - 29.01.2026
 
 ### Added

--- a/lloca/backbone/particletransformer.py
+++ b/lloca/backbone/particletransformer.py
@@ -915,7 +915,7 @@ class ParticleTransformer(nn.Module):
 
         self.embed = Embed(
             input_dim,
-            embed_dims if len(embed_dims) > 0 else (self.embed_dim),
+            embed_dims if len(embed_dims) > 0 else [self.embed_dim],
             activation=activation,
         )
 


### PR DESCRIPTION
### Goal
- Allow construction of ParT models that are similar to common transformers

### Changes
- Allow `embed_dims=[]` (preprocess node features with single linear layer instead of MLP)
- Instead of hardcoding `ffn_ratio=4`, make it a public parameter