### PR TITLE
Combination of small improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [1.3.6] - 27.04.2026
 
 ### Added
 
 - `mass_reg` option in FramesNet
-- `compile_mode` option in all compilable backbones
-
-### Changed
-
-- Handle autocast-off regions more carefully
+- `compile_mode` and `compile_dynamic` option in all compilable backbones
+- `minimum_autocast_precision` function and overall more careful `amp` handling
 
 ## [1.3.5] - 29.01.2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- `mass_reg` option in FramesNet
+- `compile_mode` option in all compilable backbones
+
 ### Changed
 
-- Make ParT `ffn_ratio` and `embed_dims` more modular
+- Handle autocast-off regions more carefully
 
 ## [1.3.5] - 29.01.2026
 
@@ -25,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Disable `torch.compile` on custom attention kernels
 - Add `dtype` keyword argument to xformers attention to allow downcasting to float16/bfloat16 and enforcing flash-attention backends
 - Write generic `get_sparse_attention_mask` function that works for all variable-length kernels; used in `equivectors/lgatr.py`
+- Make ParT `ffn_ratio` and `embed_dims` more modular
 
 ## [1.3.4] - 07.01.2026
 

--- a/lloca/backbone/__init__.py
+++ b/lloca/backbone/__init__.py
@@ -5,3 +5,4 @@ from .mlp import MLP
 from .particlenet import ParticleNet
 from .particletransformer import ParticleTransformer
 from .transformer import Transformer
+from .transformer_v2 import Transformer as TransformerV2

--- a/lloca/backbone/attention.py
+++ b/lloca/backbone/attention.py
@@ -8,6 +8,7 @@ from torch import Tensor
 from ..framesnet.frames import Frames, InverseFrames, LowerIndicesFrames
 from ..reps.tensorreps import TensorReps
 from ..reps.tensorreps_transform import TensorRepsTransform
+from ..utils.misc import minimum_autocast_precision
 from .attention_backends import get_attention_backend
 
 
@@ -30,6 +31,7 @@ class LLoCaAttention(torch.nn.Module):
         self.inv_frames = None
         self.lower_inv_frames = None
 
+    @minimum_autocast_precision(torch.float32)
     def prepare_frames(self, frames):
         """Prepare local frames for processing with LLoCa attention.
         For a single forward pass through the network, this method is

--- a/lloca/backbone/particletransformer.py
+++ b/lloca/backbone/particletransformer.py
@@ -866,6 +866,7 @@ class ParticleTransformer(nn.Module):
         use_amp=False,
         checkpoint_blocks=False,
         compile=False,
+        compile_mode="default",
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -985,7 +986,7 @@ class ParticleTransformer(nn.Module):
             self.fix_init_weight()
 
         if compile:
-            self.__class__ = torch.compile(self.__class__, dynamic=True, mode="default")
+            self.__class__ = torch.compile(self.__class__, dynamic=True, mode=compile_mode)
 
     def fix_init_weight(self):
         def rescale(param, _layer_id):

--- a/lloca/backbone/particletransformer.py
+++ b/lloca/backbone/particletransformer.py
@@ -867,7 +867,7 @@ class ParticleTransformer(nn.Module):
         checkpoint_blocks=False,
         compile=False,
         compile_mode="default",
-        compile_dynamic=False,
+        compile_dynamic=False,  # ParT does not rely on dynamic shapes that much
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)

--- a/lloca/backbone/particletransformer.py
+++ b/lloca/backbone/particletransformer.py
@@ -867,6 +867,7 @@ class ParticleTransformer(nn.Module):
         checkpoint_blocks=False,
         compile=False,
         compile_mode="default",
+        compile_dynamic=False,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -986,7 +987,9 @@ class ParticleTransformer(nn.Module):
             self.fix_init_weight()
 
         if compile:
-            self.__class__ = torch.compile(self.__class__, dynamic=True, mode=compile_mode)
+            self.__class__ = torch.compile(
+                self.__class__, dynamic=compile_dynamic, mode=compile_mode
+            )
 
     def fix_init_weight(self):
         def rescale(param, _layer_id):

--- a/lloca/backbone/transformer.py
+++ b/lloca/backbone/transformer.py
@@ -322,6 +322,8 @@ class Transformer(nn.Module):
         Dropout probability for output.
     compile : bool, optional
         Whether to compile the model with torch.compile, by default False.
+    compile_mode : str
+        torch.compile compilation mode, see torch docs for more information.
     """
 
     def __init__(
@@ -337,6 +339,7 @@ class Transformer(nn.Module):
         multi_query: bool = False,
         dropout_prob: float | None = None,
         compile: bool = False,
+        compile_mode: str = "default",
     ) -> None:
         super().__init__()
         attn_reps = TensorReps(attn_reps)
@@ -365,7 +368,7 @@ class Transformer(nn.Module):
             # ugly hack to make torch.compile convenient for users
             # the clean solution is model = torch.compile(model, **kwargs) outside of the constructor
             # note that we need fullgraph=False because of the torch.compiler.disable for attention
-            self.__class__ = torch.compile(self.__class__, dynamic=True, mode="default")
+            self.__class__ = torch.compile(self.__class__, dynamic=True, mode=compile_mode)
 
     def forward(self, inputs: torch.Tensor, frames, **attn_kwargs) -> torch.Tensor:
         """Forward pass.

--- a/lloca/backbone/transformer.py
+++ b/lloca/backbone/transformer.py
@@ -324,6 +324,8 @@ class Transformer(nn.Module):
         Whether to compile the model with torch.compile, by default False.
     compile_mode : str
         torch.compile compilation mode, see torch docs for more information.
+    compile_dynamic : bool
+        Whether to use dynamic shapes with torch.compile, by default True.
     """
 
     def __init__(
@@ -340,6 +342,7 @@ class Transformer(nn.Module):
         dropout_prob: float | None = None,
         compile: bool = False,
         compile_mode: str = "default",
+        compile_dynamic: bool = True,
     ) -> None:
         super().__init__()
         attn_reps = TensorReps(attn_reps)
@@ -368,7 +371,9 @@ class Transformer(nn.Module):
             # ugly hack to make torch.compile convenient for users
             # the clean solution is model = torch.compile(model, **kwargs) outside of the constructor
             # note that we need fullgraph=False because of the torch.compiler.disable for attention
-            self.__class__ = torch.compile(self.__class__, dynamic=True, mode=compile_mode)
+            self.__class__ = torch.compile(
+                self.__class__, dynamic=compile_dynamic, mode=compile_mode
+            )
 
     def forward(self, inputs: torch.Tensor, frames, **attn_kwargs) -> torch.Tensor:
         """Forward pass.

--- a/lloca/backbone/transformer_v2.py
+++ b/lloca/backbone/transformer_v2.py
@@ -247,6 +247,8 @@ class Transformer(nn.Module):
         Dropout probability for output.
     compile : bool, optional
         Whether to compile the model with torch.compile, by default False.
+    compile_mode : str
+        torch.compile compilation mode, see torch docs for more information.
     """
 
     def __init__(
@@ -261,6 +263,7 @@ class Transformer(nn.Module):
         mlp_factor: int = 2,
         dropout_prob: float | None = None,
         compile: bool = False,
+        compile_mode: str = "default",
     ) -> None:
         super().__init__()
         attn_reps = TensorReps(attn_reps)
@@ -288,7 +291,7 @@ class Transformer(nn.Module):
             # ugly hack to make torch.compile convenient for users
             # the clean solution is model = torch.compile(model, **kwargs) outside of the constructor
             # note that we need fullgraph=False because of the torch.compiler.disable for attention
-            self.__class__ = torch.compile(self.__class__, dynamic=True, mode="default")
+            self.__class__ = torch.compile(self.__class__, dynamic=True, mode=compile_mode)
 
     def forward(self, inputs: torch.Tensor, frames, **attn_kwargs) -> torch.Tensor:
         """Forward pass.

--- a/lloca/backbone/transformer_v2.py
+++ b/lloca/backbone/transformer_v2.py
@@ -249,6 +249,8 @@ class Transformer(nn.Module):
         Whether to compile the model with torch.compile, by default False.
     compile_mode : str
         torch.compile compilation mode, see torch docs for more information.
+    compile_dynamic : bool
+        Whether to use dynamic shapes with torch.compile, by default True.
     """
 
     def __init__(
@@ -264,6 +266,7 @@ class Transformer(nn.Module):
         dropout_prob: float | None = None,
         compile: bool = False,
         compile_mode: str = "default",
+        compile_dynamic: bool = True,
     ) -> None:
         super().__init__()
         attn_reps = TensorReps(attn_reps)
@@ -291,7 +294,9 @@ class Transformer(nn.Module):
             # ugly hack to make torch.compile convenient for users
             # the clean solution is model = torch.compile(model, **kwargs) outside of the constructor
             # note that we need fullgraph=False because of the torch.compiler.disable for attention
-            self.__class__ = torch.compile(self.__class__, dynamic=True, mode=compile_mode)
+            self.__class__ = torch.compile(
+                self.__class__, dynamic=compile_dynamic, mode=compile_mode
+            )
 
     def forward(self, inputs: torch.Tensor, frames, **attn_kwargs) -> torch.Tensor:
         """Forward pass.

--- a/lloca/framesnet/__init__.py
+++ b/lloca/framesnet/__init__.py
@@ -4,6 +4,7 @@ from .equi_frames import (
     LearnedSO2Frames,
     LearnedSO3Frames,
     LearnedSO13Frames,
+    LearnedZFrames,
 )
 from .frames import (
     ChangeOfFrames,

--- a/lloca/framesnet/equi_frames.py
+++ b/lloca/framesnet/equi_frames.py
@@ -21,6 +21,7 @@ class LearnedFrames(FramesPredictor):
         is_global=False,
         random=False,
         fix_params=False,
+        mass_reg=None,
         ortho_kwargs=None,
     ):
         """
@@ -39,6 +40,8 @@ class LearnedFrames(FramesPredictor):
             Fix the Frames-Net parameters.
             This is equivalent to random, but without the resampling.
             We find that this can be useful to avoid overfitting.
+        mass_reg: float | None
+
         ortho_kwargs: dict
             Keyword arguments for orthogonalization
         """
@@ -47,6 +50,7 @@ class LearnedFrames(FramesPredictor):
         self.equivectors = equivectors(n_vectors=n_vectors)
         self.is_global = is_global
         self.random = random
+        self.mass_reg = mass_reg
         if random or fix_params:
             self.equivectors.requires_grad_(False)
 
@@ -56,6 +60,15 @@ class LearnedFrames(FramesPredictor):
 
     def globalize_vecs_or_not(self, vecs, ptr):
         return average_event(vecs, ptr) if self.is_global else vecs
+
+    def mass_regularize(self, fourmomenta):
+        if self.mass_reg is not None:
+            mask = lorentz_squarednorm(fourmomenta) < self.mass_reg**2
+            fourmomenta[mask, 0] = (
+                (fourmomenta[mask, 1:] ** 2).sum(dim=-1).add(self.mass_reg**2).sqrt()
+            )
+
+        return fourmomenta
 
     def __repr__(self):
         classname = self.__class__.__name__
@@ -130,6 +143,7 @@ class LearnedPDFrames(LearnedFrames):
             Dictionary containing regularization information, if return_tracker is True
         """
         self.init_weights_or_not()
+        fourmomenta = self.mass_regularize(fourmomenta)
         vecs = self.equivectors(fourmomenta, scalars=scalars, ptr=ptr, **kwargs)
         vecs = self.globalize_vecs_or_not(vecs, ptr)
         boost = vecs[..., 0, :]
@@ -201,6 +215,7 @@ class LearnedSO13Frames(LearnedFrames):
             Dictionary containing regularization information, if return_tracker is True
         """
         self.init_weights_or_not()
+        fourmomenta = self.mass_regularize(fourmomenta)
         vecs = self.equivectors(fourmomenta, scalars=scalars, ptr=ptr, **kwargs)
         vecs = self.globalize_vecs_or_not(vecs, ptr)
 
@@ -266,6 +281,7 @@ class LearnedRestFrames(LearnedFrames):
             Dictionary containing regularization information, if return_tracker is True
         """
         self.init_weights_or_not()
+        fourmomenta = self.mass_regularize(fourmomenta)
         references = self.equivectors(fourmomenta, scalars=scalars, ptr=ptr, **kwargs)
         references = self.globalize_vecs_or_not(references, ptr)
 
@@ -335,6 +351,7 @@ class LearnedSO3Frames(LearnedFrames):
             Dictionary containing regularization information, if return_tracker is True
         """
         self.init_weights_or_not()
+        fourmomenta = self.mass_regularize(fourmomenta)
         references = self.equivectors(fourmomenta, scalars=scalars, ptr=ptr, **kwargs)
         references = self.globalize_vecs_or_not(references, ptr)
         fourmomenta = lorentz_eye(
@@ -415,6 +432,7 @@ class LearnedZFrames(LearnedFrames):
             Dictionary containing regularization information, if return_tracker is True
         """
         self.init_weights_or_not()
+        fourmomenta = self.mass_regularize(fourmomenta)
         vecs = self.equivectors(fourmomenta, scalars=scalars, ptr=ptr)
         vecs = self.globalize_vecs_or_not(vecs, ptr)
         boost = vecs[..., 0, :]
@@ -504,6 +522,7 @@ class LearnedSO2Frames(LearnedFrames):
             Dictionary containing regularization information, if return_tracker is True
         """
         self.init_weights_or_not()
+        fourmomenta = self.mass_regularize(fourmomenta)
         references = self.equivectors(fourmomenta, scalars=scalars, ptr=ptr, **kwargs)
         extra_references = self.globalize_vecs_or_not(references, ptr)
         fourmomenta = lorentz_eye(

--- a/lloca/framesnet/equi_frames.py
+++ b/lloca/framesnet/equi_frames.py
@@ -63,6 +63,7 @@ class LearnedFrames(FramesPredictor):
 
     def mass_regularize(self, fourmomenta):
         if self.mass_reg is not None:
+            fourmomenta = fourmomenta.clone()
             mask = lorentz_squarednorm(fourmomenta) < self.mass_reg**2
             fourmomenta[mask, 0] = (
                 (fourmomenta[mask, 1:] ** 2).sum(dim=-1).add(self.mass_reg**2).sqrt()
@@ -317,12 +318,8 @@ class LearnedSO3Frames(LearnedFrames):
             Option to compile the orthonormalization procedure.
             Does not yet give significant speedups in our tests.
         """
-        self.n_vectors = 2
-        super().__init__(
-            *args,
-            n_vectors=self.n_vectors,
-            **kwargs,
-        )
+        super().__init__(*args, n_vectors=2, **kwargs)
+
         if compile:
             self.polar_decomposition = torch.compile(
                 polar_decomposition, dynamic=True, fullgraph=True
@@ -488,12 +485,7 @@ class LearnedSO2Frames(LearnedFrames):
             Option to compile the orthonormalization procedure.
             Does not yet give significant speedups in our tests.
         """
-        self.n_vectors = 1
-        super().__init__(
-            *args,
-            n_vectors=self.n_vectors,
-            **kwargs,
-        )
+        super().__init__(*args, n_vectors=1, **kwargs)
         if compile:
             self.polar_decomposition = torch.compile(
                 polar_decomposition, dynamic=True, fullgraph=True

--- a/lloca/framesnet/nonequi_frames.py
+++ b/lloca/framesnet/nonequi_frames.py
@@ -121,7 +121,7 @@ class RandomFrames(FramesPredictor):
 
     def __repr__(self):
         string = f"RandomFrames(transform_type={self.transform_type}, is_global={self.is_global}"
-        if self.transform_type in ["lorentz", "ztransform, general_lorentz"]:
+        if self.transform_type in ["lorentz", "ztransform", "general_lorentz"]:
             string += f", std_eta={self.std_eta}"
             string += f", n_max_std_eta={self.n_max_std_eta}"
         string += ")"
@@ -150,7 +150,7 @@ class COMRandomFrames(RandomFrames):
         shape = (
             torch.Size((*fourmomenta.shape[:-2], 1))
             if self.is_global
-            else torch.Size(*fourmomenta.shape[:-1])
+            else torch.Size(fourmomenta.shape[:-1])
         )
         matrix = self.transform(shape, device=fourmomenta.device, dtype=fourmomenta.dtype)
 

--- a/lloca/reps/tensorreps_transform.py
+++ b/lloca/reps/tensorreps_transform.py
@@ -3,6 +3,7 @@
 import torch
 
 from ..framesnet.frames import Frames
+from ..utils.misc import minimum_autocast_precision
 from .tensorreps import TensorReps
 
 
@@ -61,7 +62,7 @@ class TensorRepsTransform(torch.nn.Module):
 
         self.has_higher_orders = self.reps.max_rep.rep.order > 0
 
-    @torch.autocast("cuda", enabled=False)
+    @minimum_autocast_precision(torch.float32)
     def forward(self, tensor: torch.Tensor, frames: Frames):
         """Apply a transformation to a tensor of a given representation.
 

--- a/lloca/reps/tensorreps_transform.py
+++ b/lloca/reps/tensorreps_transform.py
@@ -112,7 +112,7 @@ class TensorRepsTransform(torch.nn.Module):
         """
         output = tensor.clone()
         frames = frames.matrices.clone().to(tensor.dtype)
-        for mul_rep, [idx_start, idx_end] in zip(self.reps, self.start_end_idx, strict=False):
+        for mul_rep, [idx_start, idx_end] in zip(self.reps, self.start_end_idx, strict=True):
             mul, rep = mul_rep
             if mul == 0 or rep.order == 0:
                 continue

--- a/lloca/utils/misc.py
+++ b/lloca/utils/misc.py
@@ -1,0 +1,116 @@
+from collections.abc import Callable
+from functools import wraps
+from itertools import chain
+from typing import Any, Literal
+
+import torch
+from torch import Tensor
+
+
+def minimum_autocast_precision(
+    min_dtype: torch.dtype = torch.float32,
+    output: Literal["low", "high"] | torch.dtype | None = None,
+    which_args: list[int] | None = None,
+    which_kwargs: list[str] | None = None,
+):
+    """Decorator that ensures input tensors are autocast to a minimum precision.
+    Only has an effect in autocast-enabled regions. Otherwise, does not change the function.
+    Only floating-point inputs are modified. Non-tensors, integer tensors, and boolean tensors are
+    untouched.
+    Note: AMP is turned on and off separately for CPU and CUDA. This decorator may fail in
+    the case where both devices are used, with only one of them on AMP.
+
+    Parameters
+    ----------
+    min_dtype : dtype
+        Minimum dtype. Default: float32.
+    output: None or "low" or "high" or dtype
+        Specifies which dtypes the outputs should be cast to. Only floating-point Tensor outputs
+        are affected. If None, the outputs are not modified. If "low", the lowest-precision input
+        dtype is used. If "high", `min_dtype` or the highest-precision input dtype is used
+        (whichever is higher).
+    which_args : None or list of int
+        If not None, specifies which positional arguments are to be modified. If None (the default),
+        all positional arguments are modified (if they are Tensors and of a floating-point dtype).
+    which_kwargs : bool
+        If not None, specifies which keyword arguments are to be modified. If None (the default),
+        all keyword arguments are modified (if they are Tensors and of a floating-point dtype).
+
+    Returns
+    -------
+    decorator : Callable
+        Decorator.
+    """
+
+    def decorator(func: Callable):
+        """Decorator that casts input tensors to minimum precision."""
+
+        def _cast_in(var: Any):
+            """Casts a single input to at least 32-bit precision."""
+            if not isinstance(var, Tensor):
+                # We don't want to modify non-Tensors
+                return var
+            if not var.dtype.is_floating_point:
+                # Integer / boolean tensors are also not touched
+                return var
+            if torch.finfo(var.dtype).bits >= torch.finfo(min_dtype).bits:
+                return var
+            return var.to(min_dtype)
+
+        def _cast_out(var: Any, dtype: torch.dtype):
+            """Casts a single output to desired precision."""
+            if not isinstance(var, Tensor):
+                # We don't want to modify non-Tensors
+                return var
+            if not var.dtype.is_floating_point:
+                # Integer / boolean tensors are also not touched
+                return var
+            return var.to(dtype)
+
+        @wraps(func)
+        def decorated_func(*args: Any, **kwargs: Any):
+            """Decorated func."""
+            # Only change dtypes in autocast-enabled regions
+            if not (torch.is_autocast_enabled() or torch.is_autocast_cpu_enabled()):
+                # NB: torch.is_autocast_enabled() only checks for GPU autocast
+                # See https://github.com/pytorch/pytorch/issues/110966
+                return func(*args, **kwargs)
+            # Cast inputs to at least 32 bit
+            mod_args = [
+                _cast_in(arg) for i, arg in enumerate(args) if which_args is None or i in which_args
+            ]
+            mod_kwargs = {
+                key: _cast_in(val)
+                for key, val in kwargs.items()
+                if which_kwargs is None or key in which_kwargs
+            }
+            # Call function w/o autocast enabled
+            with (
+                torch.autocast(device_type="cuda", enabled=False),
+                torch.autocast(device_type="cpu", enabled=False),
+            ):
+                outputs = func(*mod_args, **mod_kwargs)
+            # Cast outputs to correct dtype
+            if output is None:
+                return outputs
+            if output in ["low", "high"]:
+                in_dtypes = [
+                    arg.dtype
+                    for arg in chain(args, kwargs.values())
+                    if isinstance(arg, Tensor) and arg.dtype.is_floating_point
+                ]
+                assert len(in_dtypes)
+                if output == "low":
+                    out_dtype = min([min_dtype] + in_dtypes, key=lambda dt: torch.finfo(dt).bits)
+                else:
+                    out_dtype = max(in_dtypes, key=lambda dt: torch.finfo(dt).bits)
+            else:
+                out_dtype = output
+            if isinstance(outputs, tuple):
+                return (_cast_out(val, out_dtype) for val in outputs)
+            else:
+                return _cast_out(outputs, out_dtype)
+
+        return decorated_func
+
+    return decorator

--- a/tests/lloca/equivectors/test_lgatr.py
+++ b/tests/lloca/equivectors/test_lgatr.py
@@ -30,6 +30,7 @@ _varlen_available = tuple(int(x) for x in _torch_version.split(".")[:2]) >= (2, 
     "sparse_mode, attention_backend",
     [(False, None), (True, "xformers"), (True, "flex"), (True, "flash"), (True, "varlen")],
 )
+@torch.no_grad()
 def test_equivariance(
     batch_dims,
     jet_size,


### PR DESCRIPTION
### Changes
- Add `compile_mode` option to all compilable backbone networks
- Wrap `@minimum_autocast_precision(torch.float32)` instead of `@torch.autocast("cuda", enabled=False)`; doing the latter does not automatically upcast to the higher-precision dtype
- Add `mass_reg` option in `equi_frames.py`