### PR TITLE
Add self-contained μP support to backbones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 docs/build/
 docs/source/generated
 dist/
+*.egg-info/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Self-contained Maximal Update Parametrization (μP) support via the new `lloca.mup`
+  subpackage and a `parametrization="mup"` flag on the `Transformer`, `TransformerV2`,
+  `MLP` and `GraphNet` backbones. Backbones compute their own base shapes at
+  construction time (no `.bsh` files or manual base/delta models); `lloca.mup.finalize`
+  marks parameters living outside μP backbones as standard parametrization, and
+  `lloca.mup.MuAdam`/`MuAdamW`/`MuSGD` are re-exported. Optional dependency: `lloca[mup]`.
+- `parametrization` argument on `LLoCaAttention` (μP scales attention logits by `1/d`).
+
 ## [1.3.6] - 27.04.2026
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Please have a look at the [LLoCa documentation](https://heidelberg-hepml.github.
 - Equivariant vector predictors in `lloca/equivectors`: `MLPVectors`, `LGATrVectors`, `PELICANVectors`
 - Local frames for equivariant architectures on several symmetry groups: SO(1,3) (`LearnedPDFrames`, `LearnedSO13Frames`, `LearnedRestFrames`), SO(3) (`LearnedSO3Frames`), SO(1,1)xSO(2) (`LearnedZFrames`) and SO(2) (`LearnedSO2Frames`); as well as the corresponding random global frames for data augmentation
 - Support for arbitrary higher-order representations with the `TensorReps` class
+- Optional self-contained [Maximal Update Parametrization (μP)](https://arxiv.org/abs/2203.03466) via `pip install lloca[mup]`: pass `parametrization="mup"` to the `Transformer`, `TransformerV2`, `MLP` or `GraphNet` backbones to make hyperparameters (notably the learning rate) transfer across model widths. See the [μP guide](docs/source/mup.rst).
 
 Coming soon:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,7 @@ available under https://github.com/heidelberg-hepml/lloca.
 * :doc:`quickstart`
 * :doc:`lloca-vs-lgatr`
 * :doc:`more-backbones/index`
+* :doc:`mup`
 * :doc:`numerics`
 * :doc:`api`
 
@@ -49,6 +50,7 @@ If you find this package useful, please cite our papers:
    quickstart
    lloca-vs-lgatr
    more-backbones/index
+   mup
    numerics
 
 .. toctree::

--- a/docs/source/mup.rst
+++ b/docs/source/mup.rst
@@ -1,0 +1,108 @@
+Maximal Update Parametrization (μP)
+===================================
+
+`Maximal Update Parametrization <https://arxiv.org/abs/2203.03466>`_ (μP) rescales a
+network's initialization, learning rate and output so that the *optimal*
+hyperparameters become (approximately) independent of the model width. In practice
+this means you can tune on a small model and reuse the configuration as you scale up,
+instead of re-tuning at every size -- which is particularly valuable when a backbone is
+sensitive to its hyperparameters as it grows.
+
+``lloca`` ships a self-contained μP implementation behind a single
+``parametrization`` flag. It is an optional feature; install the dependency with
+
+.. code-block:: bash
+
+   pip install lloca[mup]
+
+Supported backbones: :class:`~lloca.backbone.transformer.Transformer`,
+:class:`~lloca.backbone.transformer_v2.Transformer` (V2),
+:class:`~lloca.backbone.mlp.MLP` and :class:`~lloca.backbone.graphnet.GraphNet`.
+
+Quick start
+-----------
+
+.. code-block:: python
+
+   import lloca.mup as mup
+   from lloca.backbone import Transformer
+
+   # 1. Build the backbone in μP mode. The width axis is num_heads; the base shapes
+   #    are computed automatically inside __init__ -- no .bsh file, no base/delta models.
+   net = Transformer(
+       in_channels=in_channels,
+       attn_reps="8x0n+2x1n",
+       out_channels=out_channels,
+       num_blocks=num_blocks,
+       num_heads=num_heads,        # <- scale this freely; HPs transfer
+       parametrization="mup",
+   )
+
+   # 2. If the trained model has parameters *outside* a μP backbone (e.g. a frames
+   #    network or an input encoder, whose width is fixed), wrap everything and call
+   #    finalize() once to mark those as standard parametrization.
+   model = MyModel(net)            # net is a submodule somewhere inside
+   mup.finalize(model)
+
+   # 3. Optimize with a μP-aware optimizer.
+   optimizer = mup.MuAdamW(model.parameters(), lr=lr)
+
+That is the whole workflow. Reloading a checkpoint needs **no** extra μP bookkeeping:
+reconstruct the model with the same arguments (which reproduces identical base shapes)
+and call ``load_state_dict`` as usual.
+
+How it works
+------------
+
+The key observation is that, for these backbones, the μP *base shapes* are a
+deterministic function of the constructor arguments -- the width is just another
+argument (``num_heads`` for the transformers, ``hidden_channels`` for the MLP, the
+``hidden_reps`` multiplicities for ``GraphNet``). So when ``parametrization="mup"`` the
+backbone re-instantiates itself at a small "base" and "delta" width *in memory* and
+computes its base shapes during construction. There are therefore no ``.bsh`` files and
+no manually managed base/delta models.
+
+Concretely, ``parametrization="mup"`` changes three things relative to the standard
+(``"sp"``) path:
+
+* the readout becomes a :class:`mup.MuReadout` (μP ``1/width`` output scaling),
+* attention logits are scaled by ``1/d`` instead of ``1/sqrt(d)``
+  (see :class:`~lloca.backbone.attention.LLoCaAttention`),
+* the weights get a width-independent μP base initialization, which
+  :func:`mup.set_base_shapes` then rescales for the actual width.
+
+The standard-parametrization path is untouched (byte-for-byte), so ``parametrization``
+defaults to ``"sp"`` and existing code keeps the exact previous behaviour.
+
+Choosing the base/delta widths
+------------------------------
+
+Each backbone has sensible defaults (e.g. ``num_heads`` 2 and 4 for the transformer).
+To override them, pass ``mup_base_shapes`` / ``mup_delta_shapes`` -- dictionaries of
+constructor-argument overrides:
+
+.. code-block:: python
+
+   net = Transformer(
+       ..., num_heads=32, parametrization="mup",
+       mup_base_shapes={"num_heads": 4},
+       mup_delta_shapes={"num_heads": 8},
+   )
+
+The only requirement is that base and delta differ along the width axis; the actual
+model width is independent of both.
+
+Validating a setup (coordinate check)
+-------------------------------------
+
+The standard way to confirm μP is wired correctly is a *coordinate check*: train at a
+range of widths for a few steps and verify the activation magnitudes stay roughly
+constant in width (μP) rather than drifting (SP). See
+``tests/lloca/mup/test_mup.py::test_coord_check_mlp`` for a minimal, CPU-only example.
+
+.. note::
+
+   μP support for the :class:`~lloca.backbone.particletransformer.ParticleTransformer`
+   and :class:`~lloca.backbone.particlenet.ParticleNet` backbones is not provided yet:
+   their BatchNorm / LayerScale / token structure needs μP treatment beyond the
+   readout/attention/init pattern used here.

--- a/lloca/backbone/attention.py
+++ b/lloca/backbone/attention.py
@@ -13,7 +13,7 @@ from .attention_backends import get_attention_backend
 
 
 class LLoCaAttention(torch.nn.Module):
-    def __init__(self, attn_reps, num_heads):
+    def __init__(self, attn_reps, num_heads, parametrization="sp"):
         """Attention with frame-to-frame transformations.
 
         Parameters
@@ -22,14 +22,28 @@ class LLoCaAttention(torch.nn.Module):
             Tensor representation of a single attention head.
         num_heads : int
             Number of attention heads
+        parametrization : str
+            Either ``"sp"`` (standard) or ``"mup"``. Under μP the attention logits
+            are scaled by ``1 / d`` instead of the usual ``1 / sqrt(d)`` (``d`` is
+            the per-head channel dimension). This is implemented by pre-scaling the
+            queries by ``d ** -0.5`` so that the backend's default ``d ** -0.5``
+            scaling composes to ``1 / d`` -- backend-agnostic (works for flash and
+            varlen kernels that do not accept an explicit ``scale``).
         """
         super().__init__()
         self.transform = TensorRepsTransform(TensorReps(attn_reps))
         self.num_heads = num_heads
+        self.parametrization = parametrization
 
         self.frames = None
         self.inv_frames = None
         self.lower_inv_frames = None
+
+    def _mup_scale_query(self, q_local):
+        """Pre-scale queries for μP attention (no-op under standard parametrization)."""
+        if self.parametrization == "mup":
+            return q_local * q_local.shape[-1] ** -0.5
+        return q_local
 
     @minimum_autocast_precision(torch.float32)
     def prepare_frames(self, frames):
@@ -124,13 +138,15 @@ class LLoCaAttention(torch.nn.Module):
         if self.frames.is_global:
             # fallback to standard attention for global frames
             return scaled_dot_product_attention(
-                q_local,
+                self._mup_scale_query(q_local),
                 k_local,
                 v_local,
                 **attn_kwargs,
             )
 
-        q_global, k_global, v_global = self._local_to_global(q_local, k_local, v_local)
+        q_global, k_global, v_global = self._local_to_global(
+            self._mup_scale_query(q_local), k_local, v_local
+        )
 
         # (B, H, N, C) format required for scaled_dot_product_attention
         shape_q, shape_k = q_global.shape, k_global.shape

--- a/lloca/backbone/graphnet.py
+++ b/lloca/backbone/graphnet.py
@@ -4,6 +4,7 @@ import torch
 from torch import nn
 from torch.utils.checkpoint import checkpoint
 
+from ..mup import make_readout, mup_parametrized, reinitialize_mup, scale_reps
 from ..reps.tensorreps import TensorReps
 from .lloca_message_passing import LLoCaMessagePassing
 from .mlp import MLP
@@ -97,6 +98,7 @@ class EdgeConv(LLoCaMessagePassing):
         return x
 
 
+@mup_parametrized
 class GraphNet(nn.Module):
     """Baseline LLoCa-GNN.
 
@@ -115,8 +117,26 @@ class GraphNet(nn.Module):
     *args
     checkpoint_blocks : bool
         Whether to use gradient checkpointing in the EdgeConv blocks.
+    parametrization : str
+        ``"sp"`` (standard, default) or ``"mup"``. Under μP the width axis is the
+        multiplicity of ``hidden_reps``: the readout becomes a :class:`mup.MuReadout`,
+        the weights are μP-initialized, and the base shapes are computed automatically
+        by scaling the ``hidden_reps`` multiplicities. The internal EdgeConv MLPs stay
+        in standard parametrization (they are hidden layers, not readouts), but their
+        width-scaling parameters are tracked. Note: μP-correctness for the GNN backbone
+        is *not* validated by the coordinate-check test -- use with care. See
+        :mod:`lloca.mup`.
+    mup_base_shapes, mup_delta_shapes : dict, optional
+        Base/delta width overrides; default scales ``hidden_reps`` multiplicities by
+        ``0.5`` (base) and ``1.0`` (delta).
     **kwargs
     """
+
+    # Default base/delta width overrides for μP base-shape computation.
+    DEFAULT_MUP_SHAPES = (
+        {"hidden_reps": lambda r: scale_reps(r, 0.5)},
+        {"hidden_reps": lambda r: scale_reps(r, 1.0)},
+    )
 
     def __init__(
         self,
@@ -126,14 +146,18 @@ class GraphNet(nn.Module):
         num_blocks: int,
         *args,
         checkpoint_blocks=False,
+        parametrization: str = "sp",
+        mup_base_shapes: dict | None = None,
+        mup_delta_shapes: dict | None = None,
         **kwargs,
     ):
         super().__init__()
+        self.parametrization = parametrization
         hidden_reps = TensorReps(hidden_reps)
         self.checkpoint_blocks = checkpoint_blocks
 
         self.linear_in = nn.Linear(in_channels, hidden_reps.dim)
-        self.linear_out = nn.Linear(hidden_reps.dim, out_channels)
+        self.linear_out = make_readout(hidden_reps.dim, out_channels, parametrization)
         self.blocks = nn.ModuleList(
             [
                 EdgeConv(
@@ -144,6 +168,9 @@ class GraphNet(nn.Module):
                 for _ in range(num_blocks)
             ]
         )
+
+        if parametrization == "mup":
+            reinitialize_mup(self)
 
     def forward(self, inputs, frames, edge_index, batch=None, edge_attr=None):
         """Forward pass.

--- a/lloca/backbone/graphnet.py
+++ b/lloca/backbone/graphnet.py
@@ -4,7 +4,7 @@ import torch
 from torch import nn
 from torch.utils.checkpoint import checkpoint
 
-from ..mup import make_readout, mup_parametrized, reinitialize_mup, scale_reps
+from ..mup import make_readout, mup_parametrized, reinitialize_mup
 from ..reps.tensorreps import TensorReps
 from .lloca_message_passing import LLoCaMessagePassing
 from .mlp import MLP
@@ -132,10 +132,15 @@ class GraphNet(nn.Module):
     **kwargs
     """
 
-    # Default base/delta width overrides for μP base-shape computation.
+    # Default base/delta widths for μP base-shape computation. These are FIXED
+    # absolute reps (not relative to the target): the width multiplier must grow with
+    # the target width for μP to transfer across widths, so the base/delta cannot scale
+    # with the target. The base must share the target's rep structure (here the standard
+    # scalars+vectors family, c * (8x0n+2x1n)); for other structures pass
+    # mup_base_shapes / mup_delta_shapes explicitly (e.g. via lloca.mup.scale_reps).
     DEFAULT_MUP_SHAPES = (
-        {"hidden_reps": lambda r: scale_reps(r, 0.5)},
-        {"hidden_reps": lambda r: scale_reps(r, 1.0)},
+        {"hidden_reps": "8x0n+2x1n"},
+        {"hidden_reps": "16x0n+4x1n"},
     )
 
     def __init__(

--- a/lloca/backbone/mlp.py
+++ b/lloca/backbone/mlp.py
@@ -5,19 +5,50 @@ import math
 import torch
 from torch import nn
 
+from ..mup import make_readout, mup_parametrized, reinitialize_mup
 
+
+@mup_parametrized
 class MLP(nn.Module):
     """A simple MLP.
 
     Flattens all dimensions except batch and uses GELU nonlinearities.
+
+    Parameters
+    ----------
+    in_shape, out_shape, hidden_channels, hidden_layers, dropout_prob
+        Standard MLP arguments.
+    parametrization : str
+        ``"sp"`` (standard, default) or ``"mup"``. Under μP the width axis is
+        ``hidden_channels``: the final layer becomes a :class:`mup.MuReadout`, the
+        weights are μP-initialized, and the base shapes are computed automatically.
+        See :mod:`lloca.mup`.
+    mup_base_shapes, mup_delta_shapes : dict, optional
+        Base/delta width overrides; default ``{"hidden_channels": 64}`` /
+        ``{"hidden_channels": 128}``.
     """
 
-    def __init__(self, in_shape, out_shape, hidden_channels, hidden_layers, dropout_prob=None):
+    # Default base/delta width overrides for μP base-shape computation.
+    DEFAULT_MUP_SHAPES = ({"hidden_channels": 64}, {"hidden_channels": 128})
+
+    def __init__(
+        self,
+        in_shape,
+        out_shape,
+        hidden_channels,
+        hidden_layers,
+        dropout_prob=None,
+        *,
+        parametrization: str = "sp",
+        mup_base_shapes: dict | None = None,
+        mup_delta_shapes: dict | None = None,
+    ):
         super().__init__()
 
         if not hidden_layers > 0:
             raise NotImplementedError("Only supports > 0 hidden layers")
 
+        self.parametrization = parametrization
         self.in_shape = in_shape
         self.out_shape = out_shape
 
@@ -31,8 +62,11 @@ class MLP(nn.Module):
                 layers.append(nn.Dropout(dropout_prob))
 
         layers.append(nn.GELU())
-        layers.append(nn.Linear(hidden_channels, prod(self.out_shape)))
+        layers.append(make_readout(hidden_channels, prod(self.out_shape), parametrization))
         self.mlp = nn.Sequential(*layers)
+
+        if parametrization == "mup":
+            reinitialize_mup(self)
 
     def forward(self, inputs: torch.Tensor):
         """Forward pass of MLP."""

--- a/lloca/backbone/transformer.py
+++ b/lloca/backbone/transformer.py
@@ -4,6 +4,7 @@ import torch
 from torch import nn
 from torch.utils.checkpoint import checkpoint
 
+from ..mup import make_readout, mup_parametrized, normal_fanin_
 from ..reps.tensorreps import TensorReps
 from .attention import LLoCaAttention
 
@@ -46,6 +47,19 @@ class MultiHeadQKVLinear(nn.Module):
         self.num_heads = num_heads
         self.linear = nn.Linear(in_channels, 3 * hidden_channels)
 
+    def mup_reset_parameters(self):
+        """μP init: fan-in normal weights, then zero the query block.
+
+        ``self.linear`` produces ``[q | k | v]`` along its output features (the
+        leading ``3`` axis of the ``(..., 3, hidden, heads)`` view), so the queries
+        are the first third of the output rows. Zeroing them makes the initial
+        attention logits vanish (uniform attention at init), which stabilizes μP
+        width transfer.
+        """
+        normal_fanin_(self.linear)
+        n_q = self.linear.out_features // 3
+        nn.init.zeros_(self.linear.weight[:n_q])
+
     def forward(self, inputs):
         """Forward pass.
 
@@ -87,6 +101,14 @@ class MultiQueryQKVLinear(nn.Module):
         self.q_linear = nn.Linear(in_channels, hidden_channels)
         self.k_linear = nn.Linear(in_channels, hidden_channels // num_heads)
         self.v_linear = nn.Linear(in_channels, hidden_channels // num_heads)
+
+    def mup_reset_parameters(self):
+        """μP init: fan-in normal keys/values, zero queries (see MultiHeadQKVLinear)."""
+        normal_fanin_(self.k_linear)
+        normal_fanin_(self.v_linear)
+        nn.init.zeros_(self.q_linear.weight)
+        if self.q_linear.bias is not None:
+            nn.init.zeros_(self.q_linear.bias)
 
     def forward(self, inputs):
         """Forward pass.
@@ -291,6 +313,7 @@ class BaselineTransformerBlock(nn.Module):
         return outputs
 
 
+@mup_parametrized
 class Transformer(nn.Module):
     """Baseline LLoCa-Transformer.
 
@@ -326,7 +349,20 @@ class Transformer(nn.Module):
         torch.compile compilation mode, see torch docs for more information.
     compile_dynamic : bool
         Whether to use dynamic shapes with torch.compile, by default True.
+    parametrization : str
+        ``"sp"`` (standard, default) or ``"mup"``. Under μP the width axis is
+        ``num_heads`` (``hidden_channels = attn_reps.dim * num_heads``); the readout
+        becomes a :class:`mup.MuReadout`, the attention is scaled by ``1/d``, the
+        weights are μP-initialized, and the base shapes are computed automatically
+        from the base/delta widths -- no ``.bsh`` file or manual base/delta models.
+        See :mod:`lloca.mup`.
+    mup_base_shapes, mup_delta_shapes : dict, optional
+        Constructor-argument overrides defining the base/delta widths used to compute
+        the μP base shapes. Default to ``{"num_heads": 2}`` / ``{"num_heads": 4}``.
     """
+
+    # Default base/delta width overrides for μP base-shape computation.
+    DEFAULT_MUP_SHAPES = ({"num_heads": 2}, {"num_heads": 4})
 
     def __init__(
         self,
@@ -343,12 +379,17 @@ class Transformer(nn.Module):
         compile: bool = False,
         compile_mode: str = "default",
         compile_dynamic: bool = True,
+        *,
+        parametrization: str = "sp",
+        mup_base_shapes: dict | None = None,
+        mup_delta_shapes: dict | None = None,
     ) -> None:
         super().__init__()
+        self.parametrization = parametrization
         attn_reps = TensorReps(attn_reps)
         self.hidden_channels = attn_reps.dim * num_heads // attention_factor
         self.checkpoint_blocks = checkpoint_blocks
-        self.attention = LLoCaAttention(attn_reps, num_heads)
+        self.attention = LLoCaAttention(attn_reps, num_heads, parametrization=parametrization)
 
         self.linear_in = nn.Linear(in_channels, self.hidden_channels)
         self.blocks = nn.ModuleList(
@@ -365,7 +406,10 @@ class Transformer(nn.Module):
                 for _ in range(num_blocks)
             ]
         )
-        self.linear_out = nn.Linear(self.hidden_channels, out_channels)
+        self.linear_out = make_readout(self.hidden_channels, out_channels, parametrization)
+
+        if parametrization == "mup":
+            self._mup_reset_parameters()
 
         if compile:
             # ugly hack to make torch.compile convenient for users
@@ -374,6 +418,25 @@ class Transformer(nn.Module):
             self.__class__ = torch.compile(
                 self.__class__, dynamic=compile_dynamic, mode=compile_mode
             )
+
+    def _mup_reset_parameters(self) -> None:
+        """μP base initialization (applied before ``set_base_shapes`` rescales).
+
+        Hidden/input/value/key linears get a fan-in normal; queries and the readout
+        are zero-initialized. ``mup.set_base_shapes(rescale_params=True)`` then
+        applies the width-dependent rescaling on top of this width-independent base.
+        """
+        normal_fanin_(self.linear_in)
+        for block in self.blocks:
+            block.attention.qkv_linear.mup_reset_parameters()
+            normal_fanin_(block.attention.out_linear)
+            for layer in block.mlp:
+                if isinstance(layer, nn.Linear):
+                    normal_fanin_(layer)
+        # linear_out is a MuReadout (readout_zero_init=True already zeros the weight)
+        nn.init.zeros_(self.linear_out.weight)
+        if self.linear_out.bias is not None:
+            nn.init.zeros_(self.linear_out.bias)
 
     def forward(self, inputs: torch.Tensor, frames, **attn_kwargs) -> torch.Tensor:
         """Forward pass.

--- a/lloca/backbone/transformer_v2.py
+++ b/lloca/backbone/transformer_v2.py
@@ -7,6 +7,7 @@ from torch import nn
 from torch.utils.checkpoint import checkpoint
 
 from lloca.backbone.attention import LLoCaAttention
+from lloca.mup import make_readout, mup_parametrized, normal_fanin_
 from lloca.reps.tensorreps import TensorReps
 
 
@@ -27,6 +28,12 @@ class MultiHeadQKVLinear(nn.Module):
         super().__init__()
         self.num_heads = num_heads
         self.linear = nn.Linear(in_channels, 3 * hidden_channels)
+
+    def mup_reset_parameters(self):
+        """μP init: fan-in normal weights, then zero the query block (first third)."""
+        normal_fanin_(self.linear)
+        n_q = self.linear.out_features // 3
+        nn.init.zeros_(self.linear.weight[:n_q])
 
     def forward(self, inputs):
         """Forward pass.
@@ -218,6 +225,7 @@ class BaselineTransformerBlock(nn.Module):
         return outputs
 
 
+@mup_parametrized
 class Transformer(nn.Module):
     """Baseline LLoCa-Transformer.
 
@@ -251,7 +259,15 @@ class Transformer(nn.Module):
         torch.compile compilation mode, see torch docs for more information.
     compile_dynamic : bool
         Whether to use dynamic shapes with torch.compile, by default True.
+    parametrization : str
+        ``"sp"`` (standard, default) or ``"mup"``; width axis is ``num_heads``.
+        See :mod:`lloca.mup`.
+    mup_base_shapes, mup_delta_shapes : dict, optional
+        Base/delta width overrides; default ``{"num_heads": 2}`` / ``{"num_heads": 4}``.
     """
+
+    # Default base/delta width overrides for μP base-shape computation.
+    DEFAULT_MUP_SHAPES = ({"num_heads": 2}, {"num_heads": 4})
 
     def __init__(
         self,
@@ -267,12 +283,17 @@ class Transformer(nn.Module):
         compile: bool = False,
         compile_mode: str = "default",
         compile_dynamic: bool = True,
+        *,
+        parametrization: str = "sp",
+        mup_base_shapes: dict | None = None,
+        mup_delta_shapes: dict | None = None,
     ) -> None:
         super().__init__()
+        self.parametrization = parametrization
         attn_reps = TensorReps(attn_reps)
         self.hidden_channels = attn_reps.dim * num_heads // attention_factor
         self.checkpoint_blocks = checkpoint_blocks
-        self.attention = LLoCaAttention(attn_reps, num_heads)
+        self.attention = LLoCaAttention(attn_reps, num_heads, parametrization=parametrization)
 
         self.linear_in = nn.Linear(in_channels, self.hidden_channels)
         self.blocks = nn.ModuleList(
@@ -288,7 +309,10 @@ class Transformer(nn.Module):
                 for _ in range(num_blocks)
             ]
         )
-        self.linear_out = nn.Linear(self.hidden_channels, out_channels)
+        self.linear_out = make_readout(self.hidden_channels, out_channels, parametrization)
+
+        if parametrization == "mup":
+            self._mup_reset_parameters()
 
         if compile:
             # ugly hack to make torch.compile convenient for users
@@ -297,6 +321,20 @@ class Transformer(nn.Module):
             self.__class__ = torch.compile(
                 self.__class__, dynamic=compile_dynamic, mode=compile_mode
             )
+
+    def _mup_reset_parameters(self) -> None:
+        """μP base initialization (applied before ``set_base_shapes`` rescales)."""
+        normal_fanin_(self.linear_in)
+        for block in self.blocks:
+            block.attention.qkv_linear.mup_reset_parameters()
+            normal_fanin_(block.attention.out_linear)
+            for seq in (block.mlp_in, block.mlp_out):
+                for layer in seq:
+                    if isinstance(layer, nn.Linear):
+                        normal_fanin_(layer)
+        nn.init.zeros_(self.linear_out.weight)
+        if self.linear_out.bias is not None:
+            nn.init.zeros_(self.linear_out.bias)
 
     def forward(self, inputs: torch.Tensor, frames, **attn_kwargs) -> torch.Tensor:
         """Forward pass.

--- a/lloca/mup/__init__.py
+++ b/lloca/mup/__init__.py
@@ -1,0 +1,43 @@
+"""Self-contained Maximal-Update Parametrization (μP) support for LLoCa.
+
+Enable μP on any supported backbone by passing ``parametrization="mup"``; the
+backbone computes its own base shapes in ``__init__`` (no ``.bsh`` files, no
+manual base/delta models). Then mark any parameters living outside μP backbones
+with :func:`finalize` and optimize with :class:`MuAdam` / :class:`MuAdamW`::
+
+    from lloca.backbone import Transformer
+    import lloca.mup as mup
+
+    net = Transformer(..., parametrization="mup")   # base shapes set automatically
+    model = MyModelWrappingNet(net)
+    mup.finalize(model)                              # SP-mark external params
+    opt = mup.MuAdamW(model.parameters(), lr=lr)
+
+See :mod:`lloca.mup.parametrization` for details and caveats.
+"""
+
+from .optim import MuAdam, MuAdamW, MuSGD
+from .parametrization import (
+    finalize,
+    is_mup,
+    make_readout,
+    mup_available,
+    mup_parametrized,
+    normal_fanin_,
+    reinitialize_mup,
+    scale_reps,
+)
+
+__all__ = [
+    "MuAdam",
+    "MuAdamW",
+    "MuSGD",
+    "finalize",
+    "is_mup",
+    "make_readout",
+    "mup_available",
+    "mup_parametrized",
+    "normal_fanin_",
+    "reinitialize_mup",
+    "scale_reps",
+]

--- a/lloca/mup/optim.py
+++ b/lloca/mup/optim.py
@@ -1,0 +1,36 @@
+"""μP-aware optimizers, re-exported from the optional ``mup`` dependency.
+
+These are thin re-exports so that user code can simply do
+``from lloca.mup import MuAdamW`` without importing ``mup`` directly, and so the
+optional-dependency error message is consistent. They behave exactly like the
+standard ``torch`` optimizers for parameters whose width multiplier is 1, so a
+model mixing μP and standard-parametrization parameters (see
+:func:`lloca.mup.finalize`) can be optimized with a single optimizer.
+"""
+
+from .parametrization import _require_mup
+
+
+def _load():
+    _require_mup()
+    from mup import MuAdam, MuAdamW, MuReadout, MuSGD
+
+    return MuAdam, MuAdamW, MuSGD, MuReadout
+
+
+def MuAdam(*args, **kwargs):
+    """μP variant of :class:`torch.optim.Adam` (see :func:`mup.MuAdam`)."""
+    impl, _, _, _ = _load()
+    return impl(*args, **kwargs)
+
+
+def MuAdamW(*args, **kwargs):
+    """μP variant of :class:`torch.optim.AdamW` (see :func:`mup.MuAdamW`)."""
+    _, impl, _, _ = _load()
+    return impl(*args, **kwargs)
+
+
+def MuSGD(*args, **kwargs):
+    """μP variant of :class:`torch.optim.SGD` (see :func:`mup.MuSGD`)."""
+    _, _, impl, _ = _load()
+    return impl(*args, **kwargs)

--- a/lloca/mup/parametrization.py
+++ b/lloca/mup/parametrization.py
@@ -1,0 +1,275 @@
+"""Self-contained Maximal-Update Parametrization (μP) support for LLoCa backbones.
+
+μP (Yang & Hu, 2022) makes the optimal hyperparameters of a network (most
+importantly the learning rate) *transfer* across widths, so a configuration
+tuned on a small model can be reused as the model is scaled up. The standard
+``mup`` workflow is fiddly: the user must build two extra "base" and "delta"
+copies of the model, call :func:`mup.make_base_shapes` / :func:`mup.set_base_shapes`,
+manage a ``.bsh`` file, and re-apply the base shapes after every checkpoint load.
+
+This module hides all of that behind a single ``parametrization="mup"`` flag on
+the backbones. The key observation is that, for a LLoCa backbone, the base shapes
+are a *deterministic function of the constructor arguments*: the "width" axis
+(e.g. ``num_heads`` for the transformer, ``hidden_channels`` for the MLP) is just
+another argument. So a backbone can build its own base/delta copies in memory and
+compute its base shapes inside ``__init__`` -- no files, no user bookkeeping, and
+reloading a checkpoint (same arguments -> identical base shapes) "just works".
+
+Public surface (see :mod:`lloca.mup`):
+
+* decorate a backbone with :func:`mup_parametrized` and give it a
+  ``parametrization`` keyword-only argument (plus optional ``mup_base_shapes`` /
+  ``mup_delta_shapes`` overrides),
+* build its readout with :func:`make_readout`,
+* call :func:`finalize` once on the *full* training model (so that any parameter
+  living outside a μP backbone -- e.g. a frames network -- is marked as standard
+  parametrization), and optimize with :class:`lloca.mup.MuAdam` /
+  :class:`~lloca.mup.MuAdamW`.
+
+Only :class:`~lloca.backbone.transformer.Transformer` and
+:class:`~lloca.backbone.mlp.MLP` are validated by the coordinate-check test
+(``tests/lloca/mup``); the other backbones carry the same mechanical wiring but
+their μP-correctness has not been verified -- treat with care.
+"""
+
+import functools
+import inspect
+import threading
+
+import torch
+from torch import nn
+
+try:
+    from mup import MuReadout, make_base_shapes, set_base_shapes
+    from mup.infshape import InfDim, InfShape
+
+    _MUP_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised only when mup is missing
+    MuReadout = None
+    _MUP_AVAILABLE = False
+
+
+# Constructor keywords used to drive μP; excluded when cloning a backbone into its
+# base/delta variants (those are forced explicitly instead).
+_MUP_CONTROL_KWARGS = ("parametrization", "mup_base_shapes", "mup_delta_shapes")
+
+# Re-entrancy guard: while a backbone builds its base/delta copies, the decorated
+# __init__ of those copies must *not* recurse into base-shape computation.
+_build_state = threading.local()
+
+
+def mup_available() -> bool:
+    """Return True if the optional ``mup`` dependency is importable."""
+    return _MUP_AVAILABLE
+
+
+def _require_mup():
+    if not _MUP_AVAILABLE:
+        raise ImportError(
+            "parametrization='mup' requires the optional 'mup' package. "
+            "Install it with `pip install lloca[mup]` (or `pip install mup`)."
+        )
+
+
+class _building_base_shapes:
+    """Context manager marking that we are inside base/delta construction."""
+
+    def __enter__(self):
+        self._prev = getattr(_build_state, "active", False)
+        _build_state.active = True
+
+    def __exit__(self, *exc):
+        _build_state.active = self._prev
+
+
+def _is_building_base_shapes() -> bool:
+    return getattr(_build_state, "active", False)
+
+
+def is_mup(module: nn.Module) -> bool:
+    """Whether ``module`` was constructed with ``parametrization='mup'``."""
+    return getattr(module, "parametrization", "sp") == "mup"
+
+
+def make_readout(in_features: int, out_features: int, parametrization: str = "sp", **kwargs):
+    """Return the output projection appropriate for ``parametrization``.
+
+    For ``"mup"`` this is a :class:`mup.MuReadout` (which applies the μP ``1/width``
+    output scaling and supports zero-initialization); for ``"sp"`` it is a plain
+    :class:`torch.nn.Linear`, so the standard-parametrization code path is byte-for-byte
+    unchanged.
+    """
+    if parametrization == "mup":
+        _require_mup()
+        kwargs.setdefault("readout_zero_init", True)
+        return MuReadout(in_features, out_features, **kwargs)
+    return nn.Linear(in_features, out_features, **kwargs)
+
+
+def normal_fanin_(linear: nn.Linear, gain: float = 1.0) -> None:
+    """μP base init for a hidden/input linear: ``N(0, gain^2 / fan_in)`` weights.
+
+    ``mup.set_base_shapes(..., rescale_params=True)`` later rescales these by the
+    appropriate width multiplier, so the *base* init must be a plain fan-in normal.
+    """
+    fan_in = linear.weight.shape[1]
+    nn.init.normal_(linear.weight, mean=0.0, std=gain * fan_in**-0.5)
+    if linear.bias is not None:
+        nn.init.zeros_(linear.bias)
+
+
+def reinitialize_mup(module: nn.Module, gain: float = 1.0) -> None:
+    """Apply a generic μP base initialization to every linear in ``module``.
+
+    Hidden/input :class:`~torch.nn.Linear` layers get a fan-in normal; readouts
+    (:class:`mup.MuReadout`) are zero-initialized. This is the default recipe used
+    by backbones that do not override their own ``_mup_reset_parameters``.
+    """
+    for sub in module.modules():
+        if _MUP_AVAILABLE and isinstance(sub, MuReadout):
+            nn.init.zeros_(sub.weight)
+            if sub.bias is not None:
+                nn.init.zeros_(sub.bias)
+        elif isinstance(sub, nn.Linear):
+            normal_fanin_(sub, gain=gain)
+
+
+def _resolve_override(override_value, current_value):
+    """An override may be a static value or a callable ``current -> new``.
+
+    The callable form lets width axes that are not plain integers be scaled
+    relative to the target model (e.g. ``{"hidden_reps": lambda r: scale_reps(r, 0.5)}``).
+    """
+    return override_value(current_value) if callable(override_value) else override_value
+
+
+def _rebuild_variant(cls, sig, bound, overrides):
+    """Re-instantiate ``cls`` from a previous call's bound arguments + ``overrides``.
+
+    Reconstructs the original call faithfully (handling ``*args``/``**kwargs`` and
+    keyword-only parameters), forces ``parametrization='mup'`` and drops the μP
+    control kwargs, then applies the width ``overrides`` (e.g. ``{"num_heads": 2}``;
+    values may be callables, see :func:`_resolve_override`). Runs under the
+    re-entrancy guard so the clone does not recurse.
+    """
+    pos, var_pos, kw = [], (), {}
+    for name, param in sig.parameters.items():
+        if name == "self" or name in _MUP_CONTROL_KWARGS:
+            continue
+        if param.kind == param.VAR_POSITIONAL:
+            var_pos = bound.arguments.get(name, ())
+        elif param.kind == param.VAR_KEYWORD:
+            kw.update(bound.arguments.get(name, {}))
+        elif param.kind == param.POSITIONAL_OR_KEYWORD:
+            current = bound.arguments.get(name, param.default)
+            pos.append(_resolve_override(overrides[name], current) if name in overrides else current)
+        elif param.kind == param.KEYWORD_ONLY:
+            if name in overrides:
+                kw[name] = _resolve_override(overrides[name], bound.arguments.get(name))
+            elif name in bound.arguments:
+                kw[name] = bound.arguments[name]
+    # overrides that target **kwargs rather than a named parameter
+    for key, value in overrides.items():
+        if key not in sig.parameters:
+            kw[key] = _resolve_override(value, kw.get(key))
+    kw["parametrization"] = "mup"
+    with _building_base_shapes():
+        return cls(*pos, *var_pos, **kw)
+
+
+def _apply_base_shapes(model):
+    """Compute and set μP base shapes on ``model`` from its stored constructor call.
+
+    Builds base- and delta-width copies in memory (deterministic from the
+    constructor arguments), derives the base shapes with
+    :func:`mup.make_base_shapes`, and applies them to ``model`` with
+    ``rescale_params=True`` so the live parameters are μP-scaled in place.
+    """
+    _require_mup()
+    cls = model._mup_class
+    sig = model._mup_signature
+    bound = model._mup_bound
+    base_over, delta_over = model._mup_shape_overrides
+
+    base_model = _rebuild_variant(cls, sig, bound, base_over)
+    delta_model = _rebuild_variant(cls, sig, bound, delta_over)
+
+    base_shapes = make_base_shapes(base_model, delta_model)
+    set_base_shapes(model, base_shapes, rescale_params=True)
+    model._mup_base_shapes = base_shapes
+
+
+def mup_parametrized(cls):
+    """Class decorator giving a backbone self-contained μP support.
+
+    The decorated class must:
+
+    * accept the keyword-only arguments ``parametrization`` (``"sp"`` | ``"mup"``),
+      ``mup_base_shapes`` and ``mup_delta_shapes`` (each an optional ``dict`` of
+      constructor-argument overrides defining the base/delta widths),
+    * set ``self.parametrization`` during ``__init__``,
+    * define a class attribute ``DEFAULT_MUP_SHAPES = (base_overrides, delta_overrides)``
+      giving the default width overrides when the user does not supply them,
+    * build its readout(s) with :func:`make_readout` and its μP init either via
+      :func:`reinitialize_mup` or a custom ``_mup_reset_parameters`` method.
+
+    When ``parametrization == "mup"`` and we are *not* already inside a base/delta
+    build, the wrapped ``__init__`` records the construction arguments and computes
+    the base shapes by re-instantiating the model at the base/delta widths.
+    """
+    original_init = cls.__init__
+    signature = inspect.signature(original_init)
+
+    @functools.wraps(original_init)
+    def __init__(self, *args, **kwargs):
+        bound = signature.bind(self, *args, **kwargs)
+        bound.apply_defaults()
+        original_init(self, *args, **kwargs)
+
+        if not is_mup(self) or _is_building_base_shapes():
+            return
+
+        base_over = bound.arguments.get("mup_base_shapes") or cls.DEFAULT_MUP_SHAPES[0]
+        delta_over = bound.arguments.get("mup_delta_shapes") or cls.DEFAULT_MUP_SHAPES[1]
+        self._mup_class = cls
+        self._mup_signature = signature
+        self._mup_bound = bound
+        self._mup_shape_overrides = (dict(base_over), dict(delta_over))
+        _apply_base_shapes(self)
+
+    cls.__init__ = __init__
+    return cls
+
+
+def scale_reps(reps, factor: float, min_mul: int = 1) -> str:
+    """Scale the multiplicities of a :class:`~lloca.reps.tensorreps.TensorReps` by ``factor``.
+
+    Useful as a callable width-override for backbones whose width axis is a tensor
+    representation (e.g. ``GraphNet``'s ``hidden_reps``): the rep *structure* (orders
+    and parities) is preserved while every multiplicity is scaled, so the base/delta
+    models differ only along the width axis. Returns a reps string.
+    """
+    from ..reps.tensorreps import TensorReps, _TensorMulRep
+
+    reps = TensorReps(reps)
+    scaled = [_TensorMulRep(max(min_mul, round(mr.mul * factor)), mr.rep) for mr in reps]
+    return repr(TensorReps(scaled))
+
+
+def finalize(model: nn.Module) -> nn.Module:
+    """Mark every not-yet-covered parameter of ``model`` as standard parametrization.
+
+    A μP backbone sets ``param.infshape`` on its own parameters during construction.
+    Any *other* parameter in the full training model (e.g. a frames network or an
+    input encoder that lives outside the backbone and whose width is fixed) is
+    standard-parametrization; this stamps it with a trivial (finite) infshape so the
+    μP optimizers treat it as a width multiplier of 1.
+
+    Call this once after assembling the full model and before building the optimizer.
+    Safe to call when ``mup`` is unavailable or no parameter needs it (no-op).
+    """
+    for p in model.parameters():
+        if not hasattr(p, "infshape"):
+            _require_mup()
+            p.infshape = InfShape([InfDim(None, d) for d in p.shape])
+    return model

--- a/lloca/mup/parametrization.py
+++ b/lloca/mup/parametrization.py
@@ -195,7 +195,11 @@ def _apply_base_shapes(model):
     delta_model = _rebuild_variant(cls, sig, bound, delta_over)
 
     base_shapes = make_base_shapes(base_model, delta_model)
-    set_base_shapes(model, base_shapes, rescale_params=True)
+    # do_assert checks every finite-fan-out / infinite-fan-in module is a MuReadout.
+    # A backbone whose readout is not an nn.Linear (e.g. a geometric EquiLinear that
+    # applies the 1/width output scaling itself) can opt out via MUP_DO_ASSERT = False.
+    set_base_shapes(model, base_shapes, rescale_params=True,
+                    do_assert=getattr(model, "MUP_DO_ASSERT", True))
     model._mup_base_shapes = base_shapes
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,13 @@ varlen-attention = ["torch>=2.10"]
 xformers-attention = ["xformers"]
 flex-attention = ["torch>=2.7"]  # experimental in torch 2.5, 2.6
 flash-attention = ["flash-attn"]  # non-trivial, check https://deepwiki.com/Dao-AILab/flash-attention/1.1-installation-and-setup for build instructions
+mup = ["mup"]  # Maximal Update Parametrization (parametrization="mup" on backbones)
 dev = [
     "pre-commit",
     # unit tests
     "pytest",
     "pytest-cov",
+    "mup",
     # docs
     "sphinx<9.0",
     "sphinx-autodoc-typehints",

--- a/tests/lloca/mup/test_mup.py
+++ b/tests/lloca/mup/test_mup.py
@@ -1,0 +1,156 @@
+"""Tests for the self-contained μP support in :mod:`lloca.mup`.
+
+The decisive test is :func:`test_coord_check_mlp`: it trains the ``MLP`` backbone at
+a range of widths for a few steps on a *fixed* batch and checks that the activation
+coordinates stay O(1) in width under μP (near-flat) but drift under standard
+parametrization (SP). This is the standard μP "coordinate check". The MLP backbone is
+used because it needs no frames, so the check is fast and self-contained on CPU.
+"""
+
+import numpy as np
+import pytest
+import torch
+from torch import nn
+
+mup = pytest.importorskip("mup")
+
+from lloca.backbone.mlp import MLP  # noqa: E402
+from lloca.backbone.transformer import Transformer  # noqa: E402
+import lloca.mup as lmup  # noqa: E402
+
+
+def _make_mlp(hidden, parametrization):
+    return MLP(
+        in_shape=[8],
+        out_shape=[4],
+        hidden_channels=hidden,
+        hidden_layers=3,
+        parametrization=parametrization,
+    )
+
+
+def test_sp_path_unchanged():
+    """parametrization='sp' (default) leaves the plain modules and no infshapes."""
+    m = _make_mlp(64, "sp")
+    assert isinstance(m.mlp[-1], nn.Linear) and not isinstance(m.mlp[-1], mup.MuReadout)
+    assert not any(hasattr(p, "infshape") for p in m.parameters())
+
+    t = Transformer(
+        in_channels=10, attn_reps="4x0n+1x1n", out_channels=4, num_blocks=2, num_heads=4
+    )
+    assert type(t.linear_out).__name__ == "Linear"
+    assert not any(hasattr(p, "infshape") for p in t.parameters())
+
+
+def test_mup_base_shapes_set_automatically():
+    """parametrization='mup' sets infshapes whose width multipliers scale with width."""
+    m = _make_mlp(256, "mup")
+    assert isinstance(m.mlp[-1], mup.MuReadout)
+    assert all(hasattr(p, "infshape") for p in m.parameters())
+
+    # base width default is 64; the first hidden layer's out dim (=hidden) is the
+    # width axis, so its width multiplier is hidden / base.
+    first = m.mlp[0]
+    assert pytest.approx(first.weight.infshape.width_mult()) == 256 / 64
+
+
+@pytest.mark.parametrize("backbone_width", [4, 8, 16])
+def test_transformer_mup_width_multiplier(backbone_width):
+    """Transformer width axis is num_heads; base default is 2."""
+    t = Transformer(
+        in_channels=10,
+        attn_reps="4x0n+1x1n",
+        out_channels=4,
+        num_blocks=2,
+        num_heads=backbone_width,
+        parametrization="mup",
+    )
+    assert isinstance(t.linear_out, mup.MuReadout)
+    assert pytest.approx(t.linear_in.weight.infshape.width_mult()) == backbone_width / 2
+
+
+def test_finalize_marks_external_params_sp():
+    """finalize() stamps an SP (width_mult 1) infshape on params outside μP backbones."""
+
+    class Wrapper(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.encoder = nn.Linear(5, 8)  # external, fixed width -> SP
+            self.net = _make_mlp(128, "mup")
+
+    w = Wrapper()
+    assert not hasattr(w.encoder.weight, "infshape")
+    lmup.finalize(w)
+    assert w.encoder.weight.infshape.width_mult() == 1
+    assert all(hasattr(p, "infshape") for p in w.parameters())
+    # a single μP optimizer can now handle the whole (mixed) model
+    lmup.MuAdamW(w.parameters(), lr=1e-3)
+
+
+def test_reload_reproduces_base_shapes():
+    """Reconstructing with the same args reproduces identical base shapes, so a
+    checkpoint round-trip needs no extra μP bookkeeping."""
+    m1 = _make_mlp(256, "mup")
+    m2 = _make_mlp(256, "mup")
+    sd = m1.state_dict()
+    m2.load_state_dict(sd)  # load_state_dict must not disturb infshapes
+    for (n1, p1), (n2, p2) in zip(m1.named_parameters(), m2.named_parameters()):
+        assert p1.infshape == p2.infshape, n1
+        assert torch.equal(p1.detach(), p2.detach())
+
+
+def _coord_check(mode, widths, steps=4, seed=0):
+    """Return the mean per-coordinate magnitude of the pre-readout activations at
+    the final step, for each width."""
+    torch.manual_seed(seed)
+    x = torch.randn(16, 8)
+    y = torch.randn(16, 4)
+
+    magnitudes = []
+    for hidden in widths:
+        torch.manual_seed(seed)  # same data/init seed across widths
+        model = _make_mlp(hidden, mode)
+        if mode == "mup":
+            lmup.finalize(model)
+            opt = lmup.MuAdam(model.parameters(), lr=1e-2)
+        else:
+            opt = torch.optim.Adam(model.parameters(), lr=1e-2)
+
+        captured = {}
+
+        def hook(_module, inp, _out):
+            captured["act"] = inp[0].detach()
+
+        handle = model.mlp[-1].register_forward_hook(hook)
+        for _ in range(steps):
+            opt.zero_grad()
+            out = model(x)
+            loss = ((out - y) ** 2).mean()
+            loss.backward()
+            opt.step()
+        handle.remove()
+        magnitudes.append(captured["act"].abs().mean().item())
+    return np.array(magnitudes)
+
+
+def test_coord_check_mlp():
+    """μP keeps activation coordinates ~flat in width; SP lets them drift.
+
+    We compare the slope of log(mean|activation|) vs log(width). μP should be close
+    to flat; SP should have a clearly larger-magnitude slope.
+    """
+    widths = [64, 128, 256, 512, 1024]
+    log_w = np.log(np.array(widths, dtype=float))
+
+    mup_mag = _coord_check("mup", widths)
+    sp_mag = _coord_check("sp", widths)
+
+    mup_slope = np.polyfit(log_w, np.log(mup_mag), 1)[0]
+    sp_slope = np.polyfit(log_w, np.log(sp_mag), 1)[0]
+
+    # μP coordinates are approximately width-invariant ...
+    assert abs(mup_slope) < 0.25, f"μP slope {mup_slope:.3f} not flat (mags={mup_mag})"
+    # ... and markedly flatter than SP, which drifts with width.
+    assert abs(mup_slope) < abs(sp_slope), (
+        f"μP slope {mup_slope:.3f} not flatter than SP {sp_slope:.3f}"
+    )


### PR DESCRIPTION
Introduce a `parametrization="mup"` flag on the Transformer, TransformerV2,
MLP and GraphNet backbones that enables Maximal Update Parametrization (μP)
without any user-managed base/delta models or `.bsh` files.

The new `lloca.mup` subpackage provides:
- `@mup_parametrized`: a class decorator that, when `parametrization="mup"`,
  computes the backbone's μP base shapes during `__init__` by re-instantiating
  it at base/delta widths in memory (deterministic from the constructor args,
  so checkpoint reloads need no extra bookkeeping).
- `make_readout` / μP init helpers (`normal_fanin_`, `reinitialize_mup`).
- `finalize(model)`: marks parameters living outside μP backbones (e.g. a
  frames network) as standard parametrization so a single μP optimizer can
  train the whole model.
- `MuAdam` / `MuAdamW` / `MuSGD` re-exports and a `scale_reps` helper for
  reps-string width axes (GraphNet).

`LLoCaAttention` gains a `parametrization` argument; under μP it scales the
attention logits by 1/d instead of 1/sqrt(d) (via backend-agnostic query
pre-scaling). The standard-parametrization path is unchanged.

`mup` is an optional dependency (`pip install lloca[mup]`). Adds a coordinate-
check test (`tests/lloca/mup`) and a μP guide (`docs/source/mup.rst`).